### PR TITLE
Fix android 10 bug when resultCode is RESULT_CANCELLED instead of RESULT_OK

### DIFF
--- a/android/src/main/java/com/heanoria/library/reactnative/locationenabler/RNAndroidLocationEnablerModule.java
+++ b/android/src/main/java/com/heanoria/library/reactnative/locationenabler/RNAndroidLocationEnablerModule.java
@@ -83,6 +83,14 @@ public class RNAndroidLocationEnablerModule extends ReactContextBaseJavaModule i
             if (resultCode == RESULT_OK ) {
                 promise.resolve("enabled");
             } else {
+                // Case for Android 10 bug: user pressed 'ok' but we receive RESULT_CANCELLED
+                // https://issuetracker.google.com/issues/140447198
+                if (getCurrentActivity() != null) {
+                    LocationManager locationManager = (LocationManager) getCurrentActivity().getSystemService(Context.LOCATION_SERVICE);
+                    if (locationManager != null && locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                        promise.resolve("enabled");
+                    }
+                }
                 promise.reject(ERR_USER_DENIED_CODE, new RNAndroidLocationEnablerException("denied"));
             }
             this.promise = null;


### PR DESCRIPTION
This PR fixes the issue when user presses `ok` on the Location Modal but the returned result is `RESULT_CANCELLED` instead of `RESULT_OK`.
To fix this I am explicitly checking if location is on in case of `RESULT_CANCELLED`.

https://issuetracker.google.com/issues/140447198